### PR TITLE
#2304: Adds visual element field for concepts

### DIFF
--- a/src/main/scala/db/migration/V6__MetaImageAsVisualElement.scala
+++ b/src/main/scala/db/migration/V6__MetaImageAsVisualElement.scala
@@ -1,0 +1,132 @@
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JArray, JObject}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, Extraction}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V6__MetaImageAsVisualElement extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts()
+      migratePublishedConcepts()
+    }
+  }
+
+  def migratePublishedConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllPublishedConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allPublishedConcepts(offset * 1000).map {
+        case (id, document) => updatePublishedConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def migrateConcepts()(implicit session: DBSession): Unit = {
+    val count = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map {
+        case (id, document) => updateConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllPublishedConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+      .apply()
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from conceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+      .apply()
+  }
+
+  def allPublishedConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+      .apply()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from conceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+      .apply()
+  }
+
+  def updatePublishedConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+      .apply()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update conceptdata set document = $dataObject where id = $id"
+      .update()
+      .apply()
+  }
+
+  private def mergeFields(
+      existing: Seq[NewVisualElement],
+      updated: Seq[NewVisualElement]
+  ): Seq[NewVisualElement] = {
+    val toKeep = existing.filterNot(item => updated.map(_.language).contains(item.language))
+    (toKeep ++ updated).filterNot(_.visualElement.isEmpty)
+  }
+
+  def convertMetaImageToVisualElement(image: OldMetaImage) = {
+    val embedString =
+      s"""<embed data-resource="image" data-resource_id="${image.imageId}" data-alt="${image.altText}" data-size="full" data-align="" />"""
+    NewVisualElement(embedString, image.language)
+  }
+
+  def convertToNewConcept(document: String): String = {
+    val concept = parse(document)
+    val metaImages = (concept \ "metaImage").extract[Seq[OldMetaImage]]
+    val visualElements = (concept \ "visualElement").extract[Seq[NewVisualElement]]
+
+    val convertedVisualElements = metaImages.map(convertMetaImageToVisualElement)
+
+    val newVisualElements = mergeFields(convertedVisualElements, visualElements)
+    val newConcept = concept.merge(JObject("visualElement" -> Extraction.decompose(newVisualElements)))
+
+    compact(render(newConcept))
+  }
+
+  case class OldMetaImage(imageId: String, altText: String, language: String)
+  case class NewVisualElement(visualElement: String, language: String)
+}

--- a/src/main/scala/no/ndla/conceptapi/model/api/Concept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/Concept.scala
@@ -29,6 +29,6 @@ case class Concept(
     @(ApiModelProperty @field)(description = "All available languages of the current concept") supportedLanguages: Set[String],
     @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleId: Option[Long],
     @(ApiModelProperty @field)(description = "Status information of the concept") status: Status,
-    @(ApiModelProperty @field)(description = "A visual element article") visualElement: Option[VisualElement]
+    @(ApiModelProperty @field)(description = "A visual element for the concept") visualElement: Option[VisualElement]
     // format: on
 )

--- a/src/main/scala/no/ndla/conceptapi/model/api/Concept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/Concept.scala
@@ -29,5 +29,6 @@ case class Concept(
     @(ApiModelProperty @field)(description = "All available languages of the current concept") supportedLanguages: Set[String],
     @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleId: Option[Long],
     @(ApiModelProperty @field)(description = "Status information of the concept") status: Status,
+    @(ApiModelProperty @field)(description = "A visual element article") visualElement: Option[VisualElement]
     // format: on
 )

--- a/src/main/scala/no/ndla/conceptapi/model/api/ConceptDomainDump.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/ConceptDomainDump.scala
@@ -1,6 +1,6 @@
 /*
- * Part of NDLA draft_api.
- * Copyright (C) 2018 NDLA
+ * Part of NDLA concept-api.
+ * Copyright (C) 2020 NDLA
  *
  * See LICENSE
  */

--- a/src/main/scala/no/ndla/conceptapi/model/api/NewConcept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/NewConcept.scala
@@ -11,18 +11,18 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "Information about the concept")
 case class NewConcept(
     @(ApiModelProperty @field)(description = "The language of this concept") language: String,
     @(ApiModelProperty @field)(description = "Available titles for the concept") title: String,
     @(ApiModelProperty @field)(description = "The content of the concept") content: Option[String],
-    @(ApiModelProperty @field)(description = "Describes the copyright information for the concept") copyright: Option[
-      Copyright],
+    @(ApiModelProperty @field)(description = "Describes the copyright information for the concept") copyright: Option[Copyright],
     @(ApiModelProperty @field)(description = "URL for the source of the concept") source: Option[String],
-    @(ApiModelProperty @field)(description = "An image-api ID for the concept meta image") metaImage: Option[
-      NewConceptMetaImage],
+    @(ApiModelProperty @field)(description = "An image-api ID for the concept meta image") metaImage: Option[NewConceptMetaImage],
     @(ApiModelProperty @field)(description = "A list of searchable tags") tags: Option[Seq[String]],
-    @(ApiModelProperty @field)(description = "A list of taxonomy subject ids the concept is connected to") subjectIds: Option[
-      Seq[String]],
-    @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleId: Option[Long]
+    @(ApiModelProperty @field)(description = "A list of taxonomy subject ids the concept is connected to") subjectIds: Option[Seq[String]],
+    @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleId: Option[Long],
+    @(ApiModelProperty @field)(description = "A visual element for the concept. May be anything from an image to a video or H5P") visualElement: Option[String]
 )
+// format: on

--- a/src/main/scala/no/ndla/conceptapi/model/api/UpdatedConcept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/UpdatedConcept.scala
@@ -23,6 +23,7 @@ case class UpdatedConcept(
     @(ApiModelProperty @field)(description = "A list of searchable tags") tags: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "A list of taxonomy subject ids the concept is connected to") subjectIds: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "Article id to which the concept is connected to") articleId: Deletable[Long],
-    @(ApiModelProperty @field)(description = "The new status of the concept") status: Option[String]
+    @(ApiModelProperty @field)(description = "The new status of the concept") status: Option[String],
+    @(ApiModelProperty @field)(description = "A visual element for the concept. May be anything from an image to a video or H5P") visualElement: Option[String]
     // format: on
 )

--- a/src/main/scala/no/ndla/conceptapi/model/api/VisualElement.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/VisualElement.scala
@@ -1,6 +1,6 @@
 /*
- * Part of NDLA draft_api.
- * Copyright (C) 2017 NDLA
+ * Part of NDLA concept-api.
+ * Copyright (C) 2020 NDLA
  *
  * See LICENSE
  */

--- a/src/main/scala/no/ndla/conceptapi/model/api/VisualElement.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/VisualElement.scala
@@ -1,0 +1,21 @@
+/*
+ * Part of NDLA draft_api.
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.model.api
+
+import org.scalatra.swagger.annotations._
+import org.scalatra.swagger.runtime.annotations.ApiModelProperty
+
+import scala.annotation.meta.field
+
+// format: off
+@ApiModel(description = "Description of a visual element")
+case class VisualElement(
+    @(ApiModelProperty @field)(description = "Html containing the visual element. May contain any legal html element, including the embed-tag") visualElement: String,
+    @(ApiModelProperty @field)(description = "The ISO 639-1 language code describing which article translation this visual element belongs to") language: String
+)
+// format: on

--- a/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
@@ -102,7 +102,7 @@ object ConceptStatus extends Enumeration {
         Failure(
           new ValidationException(
             errors =
-              Seq(ValidationMessage("status", s"'$s' is not a valid article status. Must be one of $validStatuses"))))
+              Seq(ValidationMessage("status", s"'$s' is not a valid concept status. Must be one of $validStatuses"))))
     }
 
   def valueOf(s: String): Option[ConceptStatus.Value] = values.find(_.toString == s.toUpperCase)

--- a/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/domain/Concept.scala
@@ -33,7 +33,8 @@ case class Concept(
     tags: Seq[ConceptTags],
     subjectIds: Set[String],
     articleId: Option[Long],
-    status: Status
+    status: Status,
+    visualElement: Seq[VisualElement]
 ) {
 
   lazy val supportedLanguages: Set[String] =
@@ -70,7 +71,8 @@ object Concept extends SQLSyntaxSupport[Concept] {
       meta.tags,
       meta.subjectIds,
       meta.articleId,
-      meta.status
+      meta.status,
+      meta.visualElement
     )
   }
 

--- a/src/main/scala/no/ndla/conceptapi/model/domain/VisualElement.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/domain/VisualElement.scala
@@ -1,0 +1,12 @@
+/*
+ * Part of NDLA concept-api.
+ * Copyright (C) 2019 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.model.domain
+
+case class VisualElement(visualElement: String, language: String) extends LanguageField {
+  override def isEmpty: Boolean = visualElement.isEmpty
+}

--- a/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -43,6 +43,8 @@ trait ConverterService {
 
         val tags = findByLanguageOrBestEffort(concept.tags, language).map(toApiTags)
 
+        val visualElement = findByLanguageOrBestEffort(concept.visualElement, language).map(toApiVisualElement)
+
         Success(
           api.Concept(
             id = concept.id.get,
@@ -59,7 +61,8 @@ trait ConverterService {
             updatedBy = if (concept.updatedBy.isEmpty) None else Some(concept.updatedBy),
             supportedLanguages = concept.supportedLanguages,
             articleId = concept.articleId,
-            status = toApiStatus(concept.status)
+            status = toApiStatus(concept.status),
+            visualElement = visualElement
           )
         )
       } else {
@@ -116,6 +119,9 @@ trait ConverterService {
                            metaImage.altText,
                            metaImage.language)
 
+    def toApiVisualElement(visualElement: domain.VisualElement): api.VisualElement =
+      api.VisualElement(visualElement.visualElement, visualElement.language)
+
     def toDomainConcept(concept: api.NewConcept, userInfo: UserInfo): Try[domain.Concept] = {
       Success(
         domain.Concept(
@@ -134,7 +140,8 @@ trait ConverterService {
           tags = concept.tags.map(t => toDomainTags(t, concept.language)).getOrElse(Seq.empty),
           subjectIds = concept.subjectIds.getOrElse(Seq.empty).toSet,
           articleId = concept.articleId,
-          status = Status.default
+          status = Status.default,
+          visualElement = concept.visualElement.map(ve => domain.VisualElement(ve, concept.language)).toSeq
         ))
     }
 
@@ -221,7 +228,8 @@ trait ConverterService {
         tags = concept.tags.map(t => toDomainTags(t, concept.language)).getOrElse(Seq.empty),
         subjectIds = concept.subjectIds.getOrElse(Seq.empty).toSet,
         articleId = newArticleId,
-        status = Status.default
+        status = Status.default,
+        visualElement = concept.visualElement.map(ve => domain.VisualElement(ve, lang)).toSeq
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -160,6 +160,9 @@ trait ConverterService {
 
       val domainTags = updateConcept.tags.map(t => domain.ConceptTags(t, updateConcept.language)).toSeq
 
+      val domainVisualElement =
+        updateConcept.visualElement.map(ve => domain.VisualElement(ve, updateConcept.language)).toSeq
+
       val newArticleId = updateConcept.articleId match {
         case Left(_)                => None
         case Right(Some(articleId)) => Some(articleId)
@@ -194,7 +197,8 @@ trait ConverterService {
         metaImage = newMetaImage,
         tags = mergeLanguageFields(toMergeInto.tags, domainTags),
         subjectIds = updateConcept.subjectIds.map(_.toSet).getOrElse(toMergeInto.subjectIds),
-        articleId = newArticleId
+        articleId = newArticleId,
+        visualElement = mergeLanguageFields(toMergeInto.visualElement, domainVisualElement)
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -1,6 +1,6 @@
 /*
- * Part of NDLA draft-api.
- * Copyright (C) 2018 NDLA
+ * Part of NDLA concept-api.
+ * Copyright (C) 2020 NDLA
  *
  * See LICENSE
  */

--- a/src/test/scala/db/migration/V6__MetaImageAsVisualElementTest.scala
+++ b/src/test/scala/db/migration/V6__MetaImageAsVisualElementTest.scala
@@ -1,0 +1,25 @@
+package db.migration
+
+import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+
+class V6__MetaImageAsVisualElementTest extends UnitSuite with TestEnvironment {
+  val migration = new V6__MetaImageAsVisualElement
+
+  test("metaImage should be converted to visual element") {
+    val old =
+      """{"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"5522","altText":"Alttext works as well","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+    val expected =
+      """{"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"5522","altText":"Alttext works as well","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null,"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}]}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+  test("metaImage should be not override existing visual element") {
+    val old =
+      """{"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+    val expected =
+      """{"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+}

--- a/src/test/scala/no/ndla/conceptapi/IntegrationSuite.scala
+++ b/src/test/scala/no/ndla/conceptapi/IntegrationSuite.scala
@@ -12,16 +12,19 @@ import no.ndla.network.secrets.PropertyKeys
 import no.ndla.conceptapi.integration.DataSource.getHikariDataSource
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 
-import scala.util.Try
+import scala.util.{Failure, Try}
 
-abstract class IntegrationSuite extends UnitSuite {
+abstract class IntegrationSuite(withSearch: Boolean = false) extends UnitSuite {
 
-  val elasticSearchContainer = Try {
-    val esVersion = "6.3.2"
-    val c = new ElasticsearchContainer(s"docker.elastic.co/elasticsearch/elasticsearch:$esVersion")
-    c.start()
-    c
-  }
+  val elasticSearchContainer = if (withSearch) {
+    Try {
+      val esVersion = "6.3.2"
+      val c = new ElasticsearchContainer(s"docker.elastic.co/elasticsearch/elasticsearch:$esVersion")
+      c.start()
+      c
+    }
+  } else { Failure(new RuntimeException("Search disabled for this IntegrationSuite")) }
+
   val elasticSearchHost = elasticSearchContainer.map(c => s"http://${c.getHttpHostAddress}")
 
   setEnv(PropertyKeys.MetaUserNameKey, "postgres")

--- a/src/test/scala/no/ndla/conceptapi/TestData.scala
+++ b/src/test/scala/no/ndla/conceptapi/TestData.scala
@@ -50,7 +50,8 @@ object TestData {
     api.Status(
       current = "DRAFT",
       other = Seq.empty
-    )
+    ),
+    Some(api.VisualElement("VisueltElement", "nb"))
   )
 
   val sampleNbDomainConcept = domain.Concept(
@@ -67,7 +68,8 @@ object TestData {
     tags = Seq(domain.ConceptTags(Seq("stor", "kaktus"), "nb")),
     subjectIds = Set("urn:subject:3", "urn:subject:4"),
     articleId = Some(42),
-    status = Status.default
+    status = Status.default,
+    visualElement = Seq(domain.VisualElement("VisueltElement", "nb"))
   )
 
   val sampleConcept = domain.Concept(
@@ -84,7 +86,8 @@ object TestData {
     tags = Seq(domain.ConceptTags(Seq("liten", "fisk"), "nb")),
     subjectIds = Set("urn:subject:3", "urn:subject:4"),
     articleId = Some(42),
-    status = Status.default
+    status = Status.default,
+    visualElement = Seq(domain.VisualElement("VisualElement for begrep", "nb"))
   )
 
   val domainConcept = domain.Concept(
@@ -101,7 +104,8 @@ object TestData {
     tags = Seq(domain.ConceptTags(Seq("stor", "kaktus"), "nb"), domain.ConceptTags(Seq("liten", "fisk"), "nn")),
     subjectIds = Set("urn:subject:3", "urn:subject:4"),
     articleId = Some(42),
-    status = Status.default
+    status = Status.default,
+    visualElement = Seq(domain.VisualElement("VisueltElement", "nb"))
   )
 
   val domainConcept_toDomainUpdateWithId = domain.Concept(
@@ -118,7 +122,8 @@ object TestData {
     tags = Seq.empty,
     subjectIds = Set.empty,
     articleId = None,
-    status = Status.default
+    status = Status.default,
+    visualElement = Seq.empty
   )
 
   val sampleNnApiConcept = api.Concept(
@@ -139,7 +144,8 @@ object TestData {
     api.Status(
       current = "DRAFT",
       other = Seq.empty
-    )
+    ),
+    Some(api.VisualElement("VisueltElement", "nb"))
   )
 
   val emptyApiUpdatedConcept = api.UpdatedConcept(
@@ -152,10 +158,11 @@ object TestData {
     tags = None,
     subjectIds = None,
     articleId = Right(None),
-    status = None
+    status = None,
+    visualElement = None
   )
 
-  val sampleNewConcept = api.NewConcept("nb", "Tittel", Some("Innhold"), None, None, None, None, None, Some(42))
+  val sampleNewConcept = api.NewConcept("nb", "Tittel", Some("Innhold"), None, None, None, None, None, Some(42), None)
 
   val emptyApiNewConcept = api.NewConcept(
     language = "",
@@ -166,10 +173,11 @@ object TestData {
     metaImage = None,
     tags = None,
     subjectIds = None,
-    articleId = None
+    articleId = None,
+    visualElement = None
   )
 
   val updatedConcept =
-    api.UpdatedConcept("nb", None, Some("Innhold"), Right(None), None, None, None, None, Right(Some(12L)), None)
+    api.UpdatedConcept("nb", None, Some("Innhold"), Right(None), None, None, None, None, Right(Some(12L)), None, None)
   val sampleApiTagsSearchResult = api.TagsSearchResult(10, 1, 1, "nb", Seq("a", "b"))
 }

--- a/src/test/scala/no/ndla/conceptapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/ConverterServiceTest.scala
@@ -52,7 +52,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     when(clock.now()).thenReturn(updated)
 
     val updateWith =
-      UpdatedConcept("nb", Some("heisann"), None, Right(None), None, None, None, None, Right(Some(42L)), None)
+      UpdatedConcept("nb", Some("heisann"), None, Right(None), None, None, None, None, Right(Some(42L)), None, None)
     service.toDomainConcept(TestData.domainConcept, updateWith, userInfo) should be(
       TestData.domainConcept.copy(
         title = Seq(
@@ -69,7 +69,17 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     when(clock.now()).thenReturn(updated)
 
     val updateWith =
-      UpdatedConcept("nn", None, Some("Nytt innhald"), Right(None), None, None, None, None, Right(Some(42L)), None)
+      UpdatedConcept("nn",
+                     None,
+                     Some("Nytt innhald"),
+                     Right(None),
+                     None,
+                     None,
+                     None,
+                     None,
+                     Right(Some(42L)),
+                     None,
+                     None)
     service.toDomainConcept(TestData.domainConcept, updateWith, userInfo) should be(
       TestData.domainConcept.copy(
         content = Seq(
@@ -95,6 +105,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
                      None,
                      None,
                      Right(Some(42L)),
+                     None,
                      None)
     service.toDomainConcept(TestData.domainConcept, updateWith, userInfo) should be(
       TestData.domainConcept.copy(
@@ -136,6 +147,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       None,
       None,
       Right(Some(42L)),
+      None,
       None
     )
     service.toDomainConcept(TestData.domainConcept, updateWith, userInfo) should be(

--- a/src/test/scala/no/ndla/conceptapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/WriteServiceTest.scala
@@ -67,7 +67,17 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   test("That update function updates only content properly") {
     val newContent = "NewContentTest"
     val updatedApiConcept =
-      api.UpdatedConcept("en", None, content = Some(newContent), Right(None), None, None, None, None, Left(null), None)
+      api.UpdatedConcept("en",
+                         None,
+                         content = Some(newContent),
+                         Right(None),
+                         None,
+                         None,
+                         None,
+                         None,
+                         Left(null),
+                         None,
+                         None)
     val expectedConcept = concept.copy(content = Option(api.ConceptContent(newContent, "en")),
                                        updated = today,
                                        supportedLanguages = Set("nb", "en"),
@@ -79,7 +89,17 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   test("That update function updates only title properly") {
     val newTitle = "NewTitleTest"
     val updatedApiConcept =
-      api.UpdatedConcept("nn", title = Some(newTitle), None, Right(None), None, None, None, None, Left(null), None)
+      api.UpdatedConcept("nn",
+                         title = Some(newTitle),
+                         None,
+                         Right(None),
+                         None,
+                         None,
+                         None,
+                         None,
+                         Left(null),
+                         None,
+                         None)
     val expectedConcept = concept.copy(title = Option(api.ConceptTitle(newTitle, "nn")),
                                        updated = today,
                                        supportedLanguages = Set("nb", "nn"),
@@ -105,6 +125,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       Some(Seq("Nye", "Tags")),
       Some(Seq("urn:subject:900")),
       Right(Some(69L)),
+      None,
       None
     )
 

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.Outcome
 
 import scala.util.Success
 
-class DraftConceptSearchServiceTest extends IntegrationSuite with TestEnvironment {
+class DraftConceptSearchServiceTest extends IntegrationSuite(withSearch = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
 
   // Skip tests if no docker environment available

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.Outcome
 
 import scala.util.Success
 
-class PublishedConceptSearchServiceTest extends IntegrationSuite with TestEnvironment {
+class PublishedConceptSearchServiceTest extends IntegrationSuite(withSearch = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse("http://localhost:9200"))
 
   // Skip tests if no docker environment available


### PR DESCRIPTION
Relates to NDLANO/Issues#2304
- Dropper ubrukt elasticsearch container for databaseintegrasjonstester
- Legger til HTML validert visualElement field på forklaringer.
- Migrering som kopierer id og alttekst fra `metaImage` på samme språk og bygger en `embed`-tag med `data-resource="image"` og bruker den som `visualElement` dersom `visualElement` ikke finnes på språket fra før av (Både for drafts og publiserte forklaringer).