### PR TITLE
Add data-url for visual element

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/ConceptApiProperties.scala
+++ b/src/main/scala/no/ndla/conceptapi/ConceptApiProperties.scala
@@ -65,6 +65,14 @@ object ConceptApiProperties extends LazyLogging {
 
   lazy val Domain = Domains.get(Environment)
 
+  lazy val H5PAddress = propOrElse(
+    "NDLA_H5P_ADDRESS",
+    Map(
+      "test" -> "https://h5p-test.ndla.no",
+      "staging" -> "https://h5p-staging.ndla.no"
+    ).getOrElse(Environment, "https://h5p.ndla.no")
+  )
+
   lazy val secrets = {
     val SecretsFile = "concept-api.secrets"
     readSecrets(SecretsFile) match {
@@ -75,7 +83,9 @@ object ConceptApiProperties extends LazyLogging {
   }
 
   val externalApiUrls: Map[String, String] = Map(
-    "raw-image" -> s"$Domain/image-api/raw/id"
+    ResourceType.Image.toString -> s"$Domain/image-api/v2/images",
+    "raw-image" -> s"$Domain/image-api/raw/id",
+    ResourceType.H5P.toString -> H5PAddress
   )
 
   def booleanProp(key: String): Boolean = prop(key).toBoolean

--- a/src/main/scala/no/ndla/conceptapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/ReadService.scala
@@ -28,7 +28,7 @@ trait ReadService {
   class ReadService {
 
     def conceptWithId(id: Long, language: String, fallback: Boolean): Try[api.Concept] =
-      draftConceptRepository.withId(id) match {
+      draftConceptRepository.withId(id).map(addUrlOnVisualElement) match {
         case Some(concept) =>
           converterService.toApiConcept(concept, language, fallback)
         case None =>

--- a/src/main/scala/no/ndla/conceptapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/ReadService.scala
@@ -7,12 +7,18 @@
 
 package no.ndla.conceptapi.service
 
-import no.ndla.conceptapi.repository.{DraftConceptRepository, PublishedConceptRepository}
+import io.lemonlabs.uri.{Path, Url}
+import no.ndla.conceptapi.ConceptApiProperties.externalApiUrls
 import no.ndla.conceptapi.model.api
-import no.ndla.conceptapi.model.domain
 import no.ndla.conceptapi.model.api.NotFoundException
-import no.ndla.conceptapi.model.domain.Language
+import no.ndla.conceptapi.model.domain.{Concept, Language}
+import no.ndla.conceptapi.repository.{DraftConceptRepository, PublishedConceptRepository}
+import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
+import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
+import no.ndla.validation.{ResourceType, TagAttributes}
+import org.jsoup.nodes.Element
 
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 trait ReadService {
@@ -30,12 +36,54 @@ trait ReadService {
       }
 
     def publishedConceptWithId(id: Long, language: String, fallback: Boolean): Try[api.Concept] =
-      publishedConceptRepository.withId(id) match {
+      publishedConceptRepository.withId(id).map(addUrlOnVisualElement) match {
         case Some(concept) =>
           converterService.toApiConcept(concept, language, fallback)
         case None =>
           Failure(NotFoundException(s"A concept with id $id was not found with language '$language'."))
       }
+
+    def addUrlOnVisualElement(concept: Concept): Concept = {
+      val visualElementWithUrls =
+        concept.visualElement.map(visual => visual.copy(visualElement = addUrlOnElement(visual.visualElement)))
+      concept.copy(visualElement = visualElementWithUrls)
+    }
+
+    private[service] def addUrlOnElement(content: String): String = {
+      val doc = stringToJsoupDocument(content)
+
+      val embedTags = doc.select(s"$ResourceHtmlEmbedTag").asScala.toList
+      embedTags.foreach(addUrlOnEmbedTag)
+      jsoupDocumentToString(doc)
+    }
+
+    private def addUrlOnEmbedTag(embedTag: Element): Unit = {
+      val typeAndPathOption = embedTag.attr(TagAttributes.DataResource.toString) match {
+        case resourceType
+            if resourceType == ResourceType.H5P.toString
+              && embedTag.hasAttr(TagAttributes.DataPath.toString) =>
+          val path = embedTag.attr(TagAttributes.DataPath.toString)
+          Some((resourceType, path))
+
+        case resourceType if embedTag.hasAttr(TagAttributes.DataResource_Id.toString) =>
+          val id = embedTag.attr(TagAttributes.DataResource_Id.toString)
+          Some((resourceType, id))
+        case _ =>
+          None
+      }
+
+      typeAndPathOption match {
+        case Some((resourceType, path)) =>
+          val baseUrl = Url.parse(externalApiUrls(resourceType))
+          val pathParts = Path.parse(path).parts
+
+          embedTag.attr(
+            s"${TagAttributes.DataUrl}",
+            baseUrl.addPathParts(pathParts).toString
+          )
+        case _ =>
+      }
+    }
 
     def allSubjects(): Try[Set[String]] = {
       val subjectIds = publishedConceptRepository.allSubjectIds

--- a/src/test/scala/no/ndla/conceptapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/ReadServiceTest.scala
@@ -7,7 +7,8 @@
 
 package no.ndla.conceptapi.service
 import no.ndla.conceptapi.model.domain
-import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+import no.ndla.conceptapi.model.domain.{Concept, VisualElement}
+import no.ndla.conceptapi.{TestData, TestEnvironment, UnitSuite}
 import org.mockito.Mockito._
 
 class ReadServiceTest extends UnitSuite with TestEnvironment {
@@ -44,5 +45,23 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     result_en should equal(List("king", "bro", "lul", "maymay"))
     result_zh should equal(List("zing", "xiongdi", "kek", "mimi"))
     result_all should equal(List("konge", "bror", "lol", "meme"))
+  }
+
+  test("that visualElement gets url-property added") {
+    val visualElements = Seq(
+      VisualElement(
+        "<embed data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\">",
+        "nb"),
+      VisualElement("<embed data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\">", "nn")
+    )
+    when(publishedConceptRepository.withId(anyLong))
+      .thenReturn(Some(TestData.sampleConcept.copy(visualElement = visualElements)))
+    val concept = service.publishedConceptWithId(id = 1L, language = "nb", fallback = true)
+    concept.get.visualElement.get.visualElement should equal(
+      "<embed data-resource=\"image\" data-resource_id=\"1\" data-alt=\"Alt\" data-size=\"full\" data-align=\"\" data-url=\"http://api-gateway.ndla-local/image-api/v2/images/1\">")
+    val concept2 = service.publishedConceptWithId(id = 1L, language = "nn", fallback = true)
+    concept2.get.visualElement.get.visualElement should equal(
+      "<embed data-resource=\"h5p\" data-path=\"/resource/uuid\" data-title=\"Title\" data-url=\"https://h5p.ndla.no/resource/uuid\">")
+
   }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2345

For å kunne vise visuelt element via article-converter må vi legge på url på samme måte som for article-api. Koden er kopiert rått fra article-api.