### PR TITLE
Add sub keywordfield for defaulttitle used with fallback-parameter

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -46,7 +46,7 @@ trait DraftConceptIndexService {
       mapping(documentType).fields(
         List(
           intField("id"),
-          keywordField("defaultTitle"),
+          keywordField("defaultTitle").fields(keywordField("lower").normalizer("lower")),
           keywordField("subjectIds"),
           nestedField("metaImage").fields(
             keywordField("imageId"),

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -46,7 +46,7 @@ trait DraftConceptIndexService {
       mapping(documentType).fields(
         List(
           intField("id"),
-          keywordField("defaultTitle").fields(keywordField("lower").normalizer("lower")),
+          keywordField("defaultTitle").normalizer("lower"),
           keywordField("subjectIds"),
           nestedField("metaImage").fields(
             keywordField("imageId"),

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -46,7 +46,7 @@ trait PublishedConceptIndexService {
       mapping(documentType).fields(
         List(
           intField("id"),
-          keywordField("defaultTitle").fields(keywordField("lower").normalizer("lower")),
+          keywordField("defaultTitle").normalizer("lower"),
           keywordField("subjectIds"),
           nestedField("metaImage").fields(
             keywordField("imageId"),

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -46,7 +46,7 @@ trait PublishedConceptIndexService {
       mapping(documentType).fields(
         List(
           intField("id"),
-          keywordField("defaultTitle"),
+          keywordField("defaultTitle").fields(keywordField("lower").normalizer("lower")),
           keywordField("subjectIds"),
           nestedField("metaImage").fields(
             keywordField("imageId"),

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -104,7 +104,6 @@ trait PublishedConceptSearchService {
 
       val titleSearch = simpleStringQuery(query).field(s"title.$language", 2)
       val contentSearch = simpleStringQuery(query).field(s"content.$language", 1)
-      val tagSearch = simpleStringQuery(query).field(s"tags.$language", 1)
 
       val exactTitleSearch = termQuery(s"title.$language.lower", query)
 
@@ -116,8 +115,7 @@ trait PublishedConceptSearchService {
             boolQuery()
               .should(
                 titleSearch,
-                contentSearch,
-                tagSearch
+                contentSearch
               ))
       }
       executeSearch(fullQuery, settings)

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -90,12 +90,12 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle.lower").order(SortOrder.ASC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.ASC).missing("_last")
             case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.ASC).missing("_last")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle.lower").order(SortOrder.DESC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.DESC).missing("_last")
             case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.DESC).missing("_last")
           }
         case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -90,12 +90,12 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.ASC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle.lower").order(SortOrder.ASC).missing("_last")
             case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.ASC).missing("_last")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.DESC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle.lower").order(SortOrder.DESC).missing("_last")
             case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.DESC).missing("_last")
           }
         case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -228,35 +228,39 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
 
   test("That all returns all documents ordered by title ascending") {
     val Success(results) =
-      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByTitleAsc))
+      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByTitleAsc, pageSize = 20, fallback = true))
     val hits = results.results
 
-    results.totalCount should be(10)
+    results.totalCount should be(11)
+    results.totalCount should be(11)
     hits.head.id should be(8)
     hits(1).id should be(9)
     hits(2).id should be(1)
     hits(3).id should be(3)
-    hits(4).id should be(5)
-    hits(5).id should be(6)
-    hits(6).id should be(2)
-    hits(7).id should be(4)
+    hits(4).id should be(11)
+    hits(5).id should be(5)
+    hits(6).id should be(6)
+    hits(7).id should be(2)
+    hits(8).id should be(4)
+    hits(9).id should be(10)
     hits.last.id should be(7)
   }
 
   test("That all returns all documents ordered by title descending") {
     val Success(results) =
-      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByTitleDesc))
+      draftConceptSearchService.all(searchSettings.copy(sort = Sort.ByTitleDesc, pageSize = 20, fallback = true))
     val hits = results.results
-    results.totalCount should be(10)
+    results.totalCount should be(11)
     hits.head.id should be(7)
     hits(1).id should be(10)
     hits(2).id should be(4)
     hits(3).id should be(2)
     hits(4).id should be(6)
     hits(5).id should be(5)
-    hits(6).id should be(3)
-    hits(7).id should be(1)
-    hits(8).id should be(9)
+    hits(6).id should be(11)
+    hits(7).id should be(3)
+    hits(8).id should be(1)
+    hits(9).id should be(9)
     hits.last.id should be(8)
 
   }

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -460,14 +460,6 @@ class PublishedConceptSearchServiceTest
     scroll6.results.map(_.id) should be(List.empty)
   }
 
-  test("that searching for tags works") {
-    val Success(search) =
-      publishedConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "all"))
-
-    search.totalCount should be(1)
-    search.results.head.id should be(10)
-  }
-
   test("that filtering with subject id should work as expected") {
     val Success(search) =
       publishedConceptSearchService.all(searchSettings.copy(subjects = Set("urn:subject:1", "urn:subject:2")))


### PR DESCRIPTION
Ved bruk av fallback-parameter så blei språk satt til * i søket. Det førte til at sortering skjedde på defaultTitle som ikkje hadde lower-variant. PR fikser dette.