### PR TITLE
Allow visual-element to be empty on create time.

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/ConverterService.scala
@@ -143,7 +143,8 @@ trait ConverterService {
           subjectIds = concept.subjectIds.getOrElse(Seq.empty).toSet,
           articleId = concept.articleId,
           status = Status.default,
-          visualElement = concept.visualElement.map(ve => domain.VisualElement(ve, concept.language)).toSeq
+          visualElement =
+            concept.visualElement.filterNot(_.isEmpty).map(ve => domain.VisualElement(ve, concept.language)).toSeq
         ))
     }
 


### PR DESCRIPTION
Første gong du sender inn en forklaring så sendes visualElement="". Dette tolkes av ConverterService til å være en visuelt element med tomt innhold, og dermed feiler valideringa. Om du fjerner visuelt element fra en forklaring du allerede har lagra så funker det. Fiksen her skipper mapping av en Optional som har tom streng som innhold.