### PR TITLE
#2434: Fix search-context=initial (++)

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -49,13 +49,13 @@ trait DraftConceptController {
 
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           draftConceptSearchService.scroll(scroll, language) match {
             case Success(scrollResult) =>
               Ok(searchConverterService.asApiConceptSearchResult(scrollResult), getResponseScrollHeader(scrollResult))
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
 
     private def getResponseScrollHeader(result: SearchResult[_]) =

--- a/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
+++ b/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
@@ -55,13 +55,13 @@ trait PublishedConceptController {
 
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any =
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           publishedConceptSearchService.scroll(scroll, language) match {
             case Success(scrollResult) =>
               Ok(searchConverterService.asApiConceptSearchResult(scrollResult), getResponseScrollHeader(scrollResult))
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
 
     private def getResponseScrollHeader(result: SearchResult[_]) =

--- a/src/test/scala/no/ndla/conceptapi/controller/PublishedConceptControllerTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/controller/PublishedConceptControllerTest.scala
@@ -6,7 +6,9 @@
  */
 package no.ndla.conceptapi.controller
 
-import no.ndla.conceptapi.model.api.NotFoundException
+import no.ndla.conceptapi.model.api.{ConceptSummary, NotFoundException}
+import no.ndla.conceptapi.model.domain.{SearchResult, Sort}
+import no.ndla.conceptapi.model.search.SearchSettings
 import no.ndla.conceptapi.{ConceptSwagger, TestData, TestEnvironment, UnitSuite}
 import org.json4s.DefaultFormats
 import org.scalatra.test.scalatest.ScalatraFunSuite
@@ -58,6 +60,22 @@ class PublishedConceptControllerTest extends UnitSuite with TestEnvironment with
 
     get(s"/test/tags/?language=$lang") {
       status should equal(200)
+    }
+  }
+
+  test("that scrolling published doesn'thappen on 'initial'") {
+    reset(publishedConceptSearchService)
+
+    val multiResult =
+      SearchResult[ConceptSummary](0, None, 10, "nn", Seq.empty, Some("heiheihei"))
+    when(publishedConceptSearchService.all(any[SearchSettings])).thenReturn(Success(multiResult))
+
+    val expectedSettings =
+      SearchSettings.empty.copy(shouldScroll = true, pageSize = 10, sort = Sort.ByTitleDesc)
+
+    get("/test/?search-context=initial") {
+      status should be(200)
+      verify(publishedConceptSearchService, times(1)).all(eqTo(expectedSettings))
     }
   }
 


### PR DESCRIPTION
Relates to NDLANO/Issues#2434

Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting