### PR TITLE
Remove transition

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/StateTransitionRules.scala
@@ -46,7 +46,6 @@ trait StateTransitionRules {
        DRAFT                      -> DRAFT,
        DRAFT                      -> ARCHIVED                    require UserInfo.WriteRoles illegalStatuses Set(PUBLISHED),
        DRAFT                      -> QUEUED_FOR_LANGUAGE         keepStates Set(PUBLISHED),
-       DRAFT                      -> QUALITY_ASSURED             keepStates Set(PUBLISHED) require UserInfo.WriteRoles,
       (DRAFT                      -> PUBLISHED)                  keepStates Set() require UserInfo.PublishRoles withSideEffect publishConcept,
        ARCHIVED                   -> ARCHIVED,
        ARCHIVED                   -> DRAFT,


### PR DESCRIPTION
Fixes NDLANO/Issues#2438

Fjerner overgang fra kladd til publiseringsklar for å tvinge alle forklaringer via språk.