### PR TITLE
Migrate publishedconcepts articleid to articleids

### DIFF
--- a/src/main/scala/db/migration/V8__PublishedConceptArticleIdsAsList.scala
+++ b/src/main/scala/db/migration/V8__PublishedConceptArticleIdsAsList.scala
@@ -1,0 +1,84 @@
+/**
+  * Part of NDLA ndla.
+  * Copyright (C) 2019 NDLA
+  *
+  * See LICENSE
+  */
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JObject, JString, JInt}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V8__PublishedConceptArticleIdsAsList extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateConcepts
+    }
+  }
+
+  def migrateConcepts(implicit session: DBSession): Unit = {
+    val count = countAllConcepts.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allConcepts(offset * 1000).map {
+        case (id, document) => updateConcept(convertToNewConcept(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllConcepts(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from publishedconceptdata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+      .apply()
+  }
+
+  def allConcepts(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from publishedconceptdata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+      .apply()
+  }
+
+  def updateConcept(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update publishedconceptdata set document = $dataObject where id = $id"
+      .update()
+      .apply()
+  }
+
+  private[migration] def convertToNewConcept(document: String): String = {
+    val oldArticle = parse(document)
+
+
+    val newArticle = oldArticle.mapField {
+      case ("articleId", articleId: JInt) =>
+        "articleIds" -> JArray(List(articleId))
+      case x => x
+    }
+
+    val toMergeWith = JObject("articleIds" -> JArray(List.empty))
+
+    val mergedArticle = toMergeWith.merge(newArticle)
+
+    compact(render(mergedArticle))
+  }
+}

--- a/src/main/scala/db/migration/V8__PublishedConceptArticleIdsAsList.scala
+++ b/src/main/scala/db/migration/V8__PublishedConceptArticleIdsAsList.scala
@@ -68,7 +68,6 @@ class V8__PublishedConceptArticleIdsAsList extends BaseJavaMigration {
   private[migration] def convertToNewConcept(document: String): String = {
     val oldArticle = parse(document)
 
-
     val newArticle = oldArticle.mapField {
       case ("articleId", articleId: JInt) =>
         "articleIds" -> JArray(List(articleId))

--- a/src/test/scala/db/migration/V8__PublishedConceptArticleIdsAsListTest.scala
+++ b/src/test/scala/db/migration/V8__PublishedConceptArticleIdsAsListTest.scala
@@ -1,0 +1,43 @@
+package db.migration
+
+import no.ndla.conceptapi.{TestEnvironment, UnitSuite}
+
+class V8__PublishedConceptArticleIdsAsListTest extends UnitSuite with TestEnvironment {
+  val migration = new V8__PublishedConceptArticleIdsAsList
+
+  test("articleId should be converted to articleIds") {
+    val old =
+      """{"articleId":5,"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"5522","altText":"Alttext works as well","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null,"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}]}"""
+    val expected =
+      """{"articleIds":[5],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"5522","altText":"Alttext works as well","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null,"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}]}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+  test("articleId without value should be converted to articleIds with empty list") {
+    val old =
+      """{"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+    val expected =
+      """{"articleIds":[],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+  test("Concept that already have articleIds shold be unchanged.") {
+    val old =
+      """{"articleIds":[1,2],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+    val expected =
+      """{"articleIds":[1,2],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+
+  test("Concept that already have empty articleIds should be unchanged.") {
+    val old =
+      """{"articleIds":[],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+    val expected =
+      """{"articleIds":[],"tags":[],"title":[{"title":"Title","language":"nb"},{"title":"Tittel","language":"nn"}],"status":{"other":["PUBLISHED"],"current":"DRAFT"},"content":[{"content":"Content","language":"nb"},{"content":"Contentnn","language":"nn"}],"created":"2018-07-02T09:46:35Z","updated":"2020-11-09T09:48:50Z","metaImage":[{"imageId":"6622","altText":"Hva slags alttext","language":"nb"}],"visualElement":[{"visualElement":"<embed data-resource=\"image\" data-resource_id=\"5522\" data-alt=\"Alttext works as well\" data-size=\"full\" data-align=\"\" />","language":"nb"}],"updatedBy":["fsexOCfJFGOKuy1C2e71OsvQwq0NWKAK"],"subjectIds":[],"supportedLanguages":null}"""
+
+    migration.convertToNewConcept(old) should be(expected)
+  }
+}


### PR DESCRIPTION
Fixes NDLANO/Issues#2454

Concept model har blitt endret fra å innholde articleId `Long` til articleIds `Seq(Long)`

Kladd-forklaringer har allerede blitt migrert, men publiserte forklaringer ble glemt. Denne PRen innholder ny migrasjon + tester for å rette opp i dette.

Da noen artikler kan ha blitt oppdatert manuelt i ed vil jeg anta det finnes publiserte artikler med gammel struktur (articleId) og noen med ny struktur (articleIds). Har skrevet tester for å sjekke at begge deler tas hensyn til. Det skal vel være umulig at noen inneholder begge deler?