### PR TITLE
Extend search with embed-id and embed-resource parameters

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
+++ b/src/main/scala/no/ndla/conceptapi/controller/DraftConceptController.scala
@@ -79,7 +79,9 @@ trait DraftConceptController {
         tagsToFilterBy: Set[String],
         statusFilter: Set[String],
         userFilter: Seq[String],
-        shouldScroll: Boolean
+        shouldScroll: Boolean,
+        embedResource: Option[String],
+        embedId: Option[String]
     ) = {
       val settings = DraftSearchSettings(
         withIdIn = idList,
@@ -92,7 +94,9 @@ trait DraftConceptController {
         tagsToFilterBy = tagsToFilterBy,
         statusFilter = statusFilter,
         userFilter = userFilter,
-        shouldScroll = shouldScroll
+        shouldScroll = shouldScroll,
+        embedResource = embedResource,
+        embedId = embedId
       )
 
       val result = query match {
@@ -174,6 +178,8 @@ trait DraftConceptController {
         val statusesToFilterBy = paramAsListOfString(this.statusFilter.paramName)
         val usersToFilterBy = paramAsListOfString(this.userFilter.paramName)
         val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
+        val embedResource = paramOrNone(this.embedResource.paramName)
+        val embedId = paramOrNone(this.embedId.paramName)
 
         search(
           query,
@@ -187,7 +193,9 @@ trait DraftConceptController {
           tagsToFilterBy.toSet,
           statusesToFilterBy.toSet,
           usersToFilterBy,
-          shouldScroll
+          shouldScroll,
+          embedResource,
+          embedId
         )
 
       }
@@ -273,6 +281,8 @@ trait DraftConceptController {
             val statusFilter = searchParams.status
             val userFilter = searchParams.users
             val shouldScroll = searchParams.scrollId.exists(InitialScrollContextKeywords.contains)
+            val embedResource = searchParams.embedResource
+            val embedId = searchParams.embedId
 
             search(
               query,
@@ -286,7 +296,9 @@ trait DraftConceptController {
               tagsToFilterBy,
               statusFilter,
               userFilter,
-              shouldScroll
+              shouldScroll,
+              embedResource,
+              embedId
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/conceptapi/controller/NdlaController.scala
@@ -149,6 +149,10 @@ abstract class NdlaController() extends ScalatraServlet with NativeJsonSupport w
     s"""List of users to filter by.
        |The value to search for is the user-id from Auth0.""".stripMargin
   )
+
+  protected val embedResource = Param[Option[String]]("embed-resource", "Return concepts with matching embed type.")
+  protected val embedId = Param[Option[String]]("embed-id", "Return concepts with matching embed id.")
+
   protected val exactTitleMatch =
     Param[Option[Boolean]]("exact-match", "If provided, only return concept where query matches title exactly.")
 

--- a/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
+++ b/src/main/scala/no/ndla/conceptapi/controller/PublishedConceptController.scala
@@ -78,7 +78,9 @@ trait PublishedConceptController {
         subjects: Set[String],
         tagsToFilterBy: Set[String],
         exactTitleMatch: Boolean,
-        shouldScroll: Boolean
+        shouldScroll: Boolean,
+        embedResource: Option[String],
+        embedId: Option[String]
     ) = {
       val settings = SearchSettings(
         withIdIn = idList,
@@ -90,7 +92,9 @@ trait PublishedConceptController {
         subjects = subjects,
         tagsToFilterBy = tagsToFilterBy,
         exactTitleMatch = exactTitleMatch,
-        shouldScroll = shouldScroll
+        shouldScroll = shouldScroll,
+        embedResource = embedResource,
+        embedId = embedId
       )
 
       val result = query match {
@@ -170,6 +174,8 @@ trait PublishedConceptController {
         val tagsToFilterBy = paramAsListOfString(this.tagsToFilterBy.paramName)
         val exactTitleMatch = booleanOrDefault(this.exactTitleMatch.paramName, default = false)
         val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
+        val embedResource = paramOrNone(this.embedResource.paramName)
+        val embedId = paramOrNone(this.embedId.paramName)
 
         search(
           query,
@@ -182,7 +188,9 @@ trait PublishedConceptController {
           subjects.toSet,
           tagsToFilterBy.toSet,
           exactTitleMatch,
-          shouldScroll
+          shouldScroll,
+          embedResource,
+          embedId
         )
 
       }
@@ -219,6 +227,8 @@ trait PublishedConceptController {
             val tagsToFilterBy = searchParams.tags
             val exactTitleMatch = searchParams.exactTitleMatch.getOrElse(false)
             val shouldScroll = searchParams.scrollId.exists(InitialScrollContextKeywords.contains)
+            val embedResource = searchParams.embedResource
+            val embedId = searchParams.embedId
 
             search(
               query,
@@ -231,7 +241,9 @@ trait PublishedConceptController {
               subjects,
               tagsToFilterBy,
               exactTitleMatch,
-              shouldScroll
+              shouldScroll,
+              embedResource,
+              embedId
             )
           case Failure(ex) => errorHandler(ex)
         }

--- a/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchParams.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/ConceptSearchParams.scala
@@ -24,5 +24,7 @@ case class ConceptSearchParams(
   @(ApiModelProperty @field)(description = "A search context retrieved from the response header of a previous search.") scrollId: Option[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of subjects that should appear in the search.") subjects: Set[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of tags to filter the search by.") tags: Set[String],
-  @(ApiModelProperty @field)(description = "If provided, only return concept where query matches title exactly.") exactTitleMatch: Option[Boolean]
+  @(ApiModelProperty @field)(description = "If provided, only return concept where query matches title exactly.") exactTitleMatch: Option[Boolean],
+  @(ApiModelProperty @field)(description = "Embed resource type that should exist in the concepts.") embedResource: Option[String],
+  @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String]
 )

--- a/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/api/DraftConceptSearchParams.scala
@@ -25,5 +25,7 @@ case class DraftConceptSearchParams(
   @(ApiModelProperty @field)(description = "A comma-separated list of subjects that should appear in the search.") subjects: Set[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of tags to filter the search by.") tags: Set[String],
   @(ApiModelProperty @field)(description = "A comma-separated list of statuses that should appear in the search.") status: Set[String],
-  @(ApiModelProperty @field)(description = "A comma-separated list of users to filter the search by.") users: Seq[String]
+  @(ApiModelProperty @field)(description = "A comma-separated list of users to filter the search by.") users: Seq[String],
+  @(ApiModelProperty @field)(description = "Embed resource type that should exist in the concepts.") embedResource: Option[String],
+  @(ApiModelProperty @field)(description = "Embed id attribute that should exist in the concepts.") embedId: Option[String]
 )

--- a/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/DraftSearchSettings.scala
@@ -14,7 +14,9 @@ case class DraftSearchSettings(
     tagsToFilterBy: Set[String],
     statusFilter: Set[String],
     userFilter: Seq[String],
-    shouldScroll: Boolean
+    shouldScroll: Boolean,
+    embedResource: Option[String],
+    embedId: Option[String]
 )
 
 object DraftSearchSettings {
@@ -31,7 +33,9 @@ object DraftSearchSettings {
       tagsToFilterBy = Set.empty,
       statusFilter = Set.empty,
       userFilter = Seq.empty,
-      shouldScroll = false
+      shouldScroll = false,
+      embedResource = None,
+      embedId = None
     )
   }
 }

--- a/src/main/scala/no/ndla/conceptapi/model/search/SearchSettings.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/SearchSettings.scala
@@ -13,7 +13,9 @@ case class SearchSettings(
     subjects: Set[String],
     tagsToFilterBy: Set[String],
     exactTitleMatch: Boolean,
-    shouldScroll: Boolean
+    shouldScroll: Boolean,
+    embedResource: Option[String],
+    embedId: Option[String]
 )
 
 object SearchSettings {
@@ -29,7 +31,9 @@ object SearchSettings {
       subjects = Set.empty,
       tagsToFilterBy = Set.empty,
       exactTitleMatch = false,
-      shouldScroll = false
+      shouldScroll = false,
+      embedResource = None,
+      embedId = None
     )
   }
 }

--- a/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -21,5 +21,7 @@ case class SearchableConcept(
     lastUpdated: DateTime,
     status: Status,
     updatedBy: Seq[String],
-    license: Option[String]
+    license: Option[String],
+    embedResources: SearchableLanguageList,
+    embedIds: SearchableLanguageList
 )

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -61,7 +61,9 @@ trait DraftConceptIndexService {
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++
-          generateLanguageSupportedFieldList("tags", keepRaw = true)
+          generateLanguageSupportedFieldList("tags", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -109,7 +109,8 @@ trait DraftConceptSearchService {
               List(
                 simpleStringQuery(query).field(s"title.$language", 2),
                 simpleStringQuery(query).field(s"content.$language", 1),
-                simpleStringQuery(query).field(s"tags.$language", 1)
+                simpleStringQuery(query).field(s"tags.$language", 1),
+                idsQuery(query)
               ) ++
                 buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
                 buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -102,18 +102,19 @@ trait DraftConceptSearchService {
     def matchingQuery(query: String, settings: DraftSearchSettings): Try[SearchResult[api.ConceptSummary]] = {
       val language = if (settings.searchLanguage == Language.AllLanguages) "*" else settings.searchLanguage
 
-      val titleSearch = simpleStringQuery(query).field(s"title.$language", 2)
-      val contentSearch = simpleStringQuery(query).field(s"content.$language", 1)
-      val tagSearch = simpleStringQuery(query).field(s"tags.$language", 1)
-
       val fullQuery = boolQuery()
         .must(
           boolQuery()
             .should(
-              titleSearch,
-              contentSearch,
-              tagSearch
-            ))
+              List(
+                simpleStringQuery(query).field(s"title.$language", 2),
+                simpleStringQuery(query).field(s"content.$language", 1),
+                simpleStringQuery(query).field(s"tags.$language", 1)
+              ) ++
+                buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
+                buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
+            )
+        )
 
       executeSearch(fullQuery, settings)
     }
@@ -135,7 +136,35 @@ trait DraftConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, statusFilter, userFilter)
+      val embedResourceFilter = settings.embedResource match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      val embedIdFilter = settings.embedId match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      val filters = List(idFilter,
+                         languageFilter,
+                         subjectFilter,
+                         tagFilter,
+                         statusFilter,
+                         userFilter,
+                         embedResourceFilter,
+                         embedIdFilter)
+
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
       val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -58,7 +58,9 @@ trait PublishedConceptIndexService {
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++
-          generateLanguageSupportedFieldList("tags", keepRaw = true)
+          generateLanguageSupportedFieldList("tags", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -102,21 +102,21 @@ trait PublishedConceptSearchService {
     def matchingQuery(query: String, settings: SearchSettings): Try[SearchResult[api.ConceptSummary]] = {
       val language = if (settings.searchLanguage == Language.AllLanguages) "*" else settings.searchLanguage
 
-      val titleSearch = simpleStringQuery(query).field(s"title.$language", 2)
-      val contentSearch = simpleStringQuery(query).field(s"content.$language", 1)
-
-      val exactTitleSearch = termQuery(s"title.$language.lower", query)
-
       val fullQuery = settings.exactTitleMatch match {
         case true =>
-          boolQuery().must(exactTitleSearch)
+          boolQuery().must(termQuery(s"title.$language.lower", query))
         case false =>
           boolQuery().must(
             boolQuery()
               .should(
-                titleSearch,
-                contentSearch
-              ))
+                List(
+                  simpleStringQuery(query).field(s"title.$language", 2),
+                  simpleStringQuery(query).field(s"content.$language", 1)
+                ) ++
+                  buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
+                  buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
+              )
+          )
       }
       executeSearch(fullQuery, settings)
     }
@@ -136,7 +136,27 @@ trait PublishedConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter)
+      val embedResourceFilter = settings.embedResource match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      val embedIdFilter = settings.embedId match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, embedResourceFilter, embedIdFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
       val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -111,7 +111,8 @@ trait PublishedConceptSearchService {
               .should(
                 List(
                   simpleStringQuery(query).field(s"title.$language", 2),
-                  simpleStringQuery(query).field(s"content.$language", 1)
+                  simpleStringQuery(query).field(s"content.$language", 1),
+                  idsQuery(query)
                 ) ++
                   buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
                   buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -8,10 +8,10 @@
 package no.ndla.conceptapi.service.search
 
 import java.lang.Math.max
-
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.search.SearchResponse
 import com.sksamuel.elastic4s.searches.queries.BoolQuery
+import com.sksamuel.elastic4s.searches.queries.term.TermQuery
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import com.typesafe.scalalogging.LazyLogging
 import org.elasticsearch.ElasticsearchException
@@ -153,6 +153,19 @@ trait SearchService {
               Failure(new ElasticsearchException(s"Unable to execute search in $searchIndex", e.getMessage))
           }
         case t: Throwable => Failure(t)
+      }
+    }
+
+    def buildTermQueryForField(
+        query: String,
+        field: String,
+        language: String,
+        fallback: Boolean
+    ): Seq[TermQuery] = {
+      if (language == Language.AllLanguages || fallback) {
+        Language.languageAnalyzers.map(lang => termQuery(s"$field.${lang.lang}.raw", query))
+      } else {
+        Seq(termQuery(s"$field.$language.raw", query))
       }
     }
   }

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -614,6 +614,50 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     search.results.head.id should be(9)
   }
 
+  test("that search on query parameter as embedId matches meta image") {
+    val Success(search) =
+      draftConceptSearchService.matchingQuery(
+        "test.image",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(9)
+  }
+
+  test("that search on query parameter as embedResource matches visual element") {
+    val Success(search) =
+      draftConceptSearchService.matchingQuery(
+        "image",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on query parameter as embedId matches visual element") {
+    val Success(search) =
+      draftConceptSearchService.matchingQuery(
+        "test.url",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on query parameter matches on concept id") {
+    val Success(search) =
+      draftConceptSearchService.matchingQuery(
+        "2",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(2)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -575,6 +575,50 @@ class PublishedConceptSearchServiceTest
     search.results.head.id should be(9)
   }
 
+  test("that search on query parameter as embedId matches meta image") {
+    val Success(search) =
+      publishedConceptSearchService.matchingQuery(
+        "test.image",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(9)
+  }
+
+  test("that search on query parameter as embedResource matches visual element") {
+    val Success(search) =
+      publishedConceptSearchService.matchingQuery(
+        "image",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on query parameter as embedId matches visual element") {
+    val Success(search) =
+      publishedConceptSearchService.matchingQuery(
+        "test.url",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on query parameter matches on concept id") {
+    val Success(search) =
+      publishedConceptSearchService.matchingQuery(
+        "2",
+        searchSettings.copy()
+      )
+
+    search.totalCount should be(1)
+    search.results.head.id should be(2)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -122,7 +122,8 @@ class PublishedConceptSearchServiceTest
     title = List(ConceptTitle("baldur har mareritt om Ragnarok", "nb")),
     content = List(ConceptContent("<p>Bilde av <em>Baldurs</em> som har  mareritt.", "nb")),
     tags = Seq(ConceptTags(Seq("stor", "klovn"), "nb")),
-    subjectIds = Set("urn:subject:1", "urn:subject:100")
+    subjectIds = Set("urn:subject:1", "urn:subject:100"),
+    metaImage = Seq(ConceptMetaImage("test.image", "imagealt", "nb"))
   )
 
   val concept10: Concept = TestData.sampleConcept.copy(
@@ -131,7 +132,8 @@ class PublishedConceptSearchServiceTest
     content = List(ConceptContent("Pompel", "en"), ConceptContent("Pilt", "nb")),
     tags = Seq(ConceptTags(Seq("cageowl"), "en"), ConceptTags(Seq("burugle"), "nb")),
     updated = DateTime.now().minusDays(1).toDate,
-    subjectIds = Set("urn:subject:2")
+    subjectIds = Set("urn:subject:2"),
+    visualElement = List(VisualElement("""<embed data-resource="image" data-url="test.url" />""", "nb"))
   )
 
   val concept11: Concept = TestData.sampleConcept.copy(id = Option(11),
@@ -148,7 +150,9 @@ class PublishedConceptSearchServiceTest
     subjects = Set.empty,
     tagsToFilterBy = Set.empty,
     exactTitleMatch = false,
-    shouldScroll = false
+    shouldScroll = false,
+    embedResource = None,
+    embedId = None
   )
 
   override def beforeAll(): Unit = if (elasticSearchContainer.isSuccess) {
@@ -542,6 +546,33 @@ class PublishedConceptSearchServiceTest
           language = "nb"
         ),
       ))
+  }
+
+  test("that search on embedId matches visual element") {
+    val Success(search) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.url"), searchLanguage = Language.AllLanguages))
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on embedResource matches visual element") {
+    val Success(search) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(embedResource = Some("image"), searchLanguage = Language.AllLanguages))
+
+    search.totalCount should be(1)
+    search.results.head.id should be(10)
+  }
+
+  test("that search on embedId matches meta image") {
+    val Success(search) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.image"), searchLanguage = Language.AllLanguages))
+
+    search.totalCount should be(1)
+    search.results.head.id should be(9)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {


### PR DESCRIPTION
Fixes NDLANO/Issues#2496

Utvider søk på concept-api med mulighet til å søke med embed-id og embed-resource som parameter. Gir også treff på query-parameter.

Har i tillegg lagt til treff på forklarings-id på query-parameter.

