### PR TITLE
#2501: Take language and fallback into account when searching for tags

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -76,9 +76,14 @@ trait SearchService {
           )
         )
 
-    protected def languageOrFilter(seq: Iterable[Any], fieldName: String): Option[BoolQuery] = {
-      val fields = ISO639.languagePriority.map(l => s"$fieldName.$l.raw")
-      orFilter(seq, fields: _*)
+    protected def languageOrFilter(seq: Iterable[Any],
+                                   fieldName: String,
+                                   language: String,
+                                   fallback: Boolean): Option[BoolQuery] = {
+      if (language == Language.AllLanguages || language == "*" || fallback) {
+        val fields = ISO639.languagePriority.map(l => s"$fieldName.$l.raw")
+        orFilter(seq, fields: _*)
+      } else { orFilter(seq, s"$fieldName.$language.raw") }
     }
 
     def getSortDefinition(sort: Sort.Value, language: String): FieldSort = {
@@ -90,33 +95,33 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.ASC).missing("_last")
-            case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.ASC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Asc).missing("_last")
+            case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.Asc).missing("_last")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.DESC).missing("_last")
-            case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.DESC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Desc).missing("_last")
+            case _                           => fieldSort(s"title.$sortLanguage.lower").order(SortOrder.Desc).missing("_last")
           }
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.DESC)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.ASC).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.DESC).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.ASC).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.DESC).missing("_last")
+        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
+        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
+        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
+        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
+        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
+        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
       }
     }
 
     def getSortDefinition(sort: Sort.Value): FieldSort = {
       sort match {
-        case Sort.ByTitleAsc        => fieldSort("title.lower").order(SortOrder.ASC).missing("_last")
-        case Sort.ByTitleDesc       => fieldSort("title.lower").order(SortOrder.DESC).missing("_last")
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.DESC)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.ASC).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.DESC).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.ASC).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.DESC).missing("_last")
+        case Sort.ByTitleAsc        => fieldSort("title.lower").order(SortOrder.Asc).missing("_last")
+        case Sort.ByTitleDesc       => fieldSort("title.lower").order(SortOrder.Desc).missing("_last")
+        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
+        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
+        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
+        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
+        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
+        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -459,7 +459,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     search2.totalCount should be(0)
 
     val Success(search3) =
-      draftConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "all"))
+      draftConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "en", fallback = true))
 
     search3.totalCount should be(1)
     search3.results.head.id should be(10)

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -446,12 +446,23 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     scroll6.results.map(_.id) should be(List.empty)
   }
 
-  test("that searching for tags works") {
+  test("that searching for tags works and respects language/fallback") {
     val Success(search) =
       draftConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "all"))
 
     search.totalCount should be(1)
     search.results.head.id should be(10)
+
+    val Success(search2) =
+      draftConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "en"))
+
+    search2.totalCount should be(0)
+
+    val Success(search3) =
+      draftConceptSearchService.matchingQuery("burugle", searchSettings.copy(searchLanguage = "all"))
+
+    search3.totalCount should be(1)
+    search3.results.head.id should be(10)
   }
 
   test("that filtering with subject id should work as expected") {

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -468,7 +468,7 @@ class PublishedConceptSearchServiceTest
     search.results.map(_.id) should be(Seq(9, 10))
   }
 
-  test("that filtering for tags works as expected") {
+  test("that filtering for tags works as expected and respects language/fallback") {
     val Success(search) = publishedConceptSearchService.all(searchSettings.copy(tagsToFilterBy = Set("burugle")))
     search.totalCount should be(1)
     search.results.map(_.id) should be(Seq(10))
@@ -477,6 +477,16 @@ class PublishedConceptSearchServiceTest
       publishedConceptSearchService.all(searchSettings.copy(tagsToFilterBy = Set("burugle"), searchLanguage = "all"))
     search1.totalCount should be(1)
     search1.results.map(_.id) should be(Seq(10))
+
+    val Success(search2) =
+      publishedConceptSearchService.all(searchSettings.copy(tagsToFilterBy = Set("burugle"), searchLanguage = "en"))
+    search2.totalCount should be(0)
+
+    val Success(search3) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(tagsToFilterBy = Set("burugle"), searchLanguage = "en", fallback = true))
+    search3.totalCount should be(1)
+    search3.results.map(_.id) should be(Seq(10))
   }
 
   test("That tag search works as expected") {


### PR DESCRIPTION
Fixes NDLANO/Issues#2501

Kan testes ved å gjøre søke etter noe på noe som finnes i et språk som ikke skal dukke opp.
Eks fra trello: `/concept-api/v1/drafts/?language=nn&tags=Begrep::` gir resultater på forklaringer som har `Begrep::` i `nb` utgaven, selvom vi søker på `nn`.