### PR TITLE
2521 Embed search combined parameters

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/model/search/EmbedValues.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/EmbedValues.scala
@@ -1,0 +1,14 @@
+/*
+ * Part of NDLA search_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.conceptapi.model.search
+
+case class EmbedValues(
+    id: Option[String],
+    resource: Option[String],
+    language: String
+)

--- a/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -23,4 +23,8 @@ case class SearchableConcept(
     updatedBy: Seq[String],
     license: Option[String],
     embedResourcesAndIds: List[EmbedValues],
+    // To be removed
+    embedResources: SearchableLanguageList,
+    // To be removed
+    embedIds: SearchableLanguageList
 )

--- a/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/SearchableConcept.scala
@@ -22,6 +22,5 @@ case class SearchableConcept(
     status: Status,
     updatedBy: Seq[String],
     license: Option[String],
-    embedResources: SearchableLanguageList,
-    embedIds: SearchableLanguageList
+    embedResourcesAndIds: List[EmbedValues],
 )

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -66,7 +66,11 @@ trait DraftConceptIndexService {
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++
-          generateLanguageSupportedFieldList("tags", keepRaw = true)
+          generateLanguageSupportedFieldList("tags", keepRaw = true) ++
+          // To be removed
+          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          // To be removed
+          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptIndexService.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.conceptapi.service.search
 
-import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.ElasticDsl.{nestedField, _}
 import com.sksamuel.elastic4s.indexes.IndexRequest
 import com.sksamuel.elastic4s.mappings.MappingDefinition
 import com.typesafe.scalalogging.LazyLogging
@@ -57,13 +57,16 @@ trait DraftConceptIndexService {
           keywordField("status.current"),
           keywordField("status.other"),
           keywordField("updatedBy"),
-          keywordField("license")
+          keywordField("license"),
+          nestedField("embedResourcesAndIds").fields(
+            keywordField("resource"),
+            keywordField("id"),
+            keywordField("language")
+          )
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++
-          generateLanguageSupportedFieldList("tags", keepRaw = true) ++
-          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
-          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
+          generateLanguageSupportedFieldList("tags", keepRaw = true)
       )
     }
 

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -113,14 +113,8 @@ trait DraftConceptSearchService {
                 simpleStringQuery(query).field(s"tags.$language", 1),
                 idsQuery(query)
               ) ++
-                // To be removed
-                buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
-                // To be removed
-                buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
-              // To be added
-              /*++
                 buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)*/
+                buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
             )
         )
 
@@ -140,31 +134,8 @@ trait DraftConceptSearchService {
         case lang                             => (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      // To be added
-      /* val embedResourceAndIdFilter =
-        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)*/
-
-      // To be removed
-      val embedResourceFilter = settings.embedResource match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
-              ))
-      }
-
-      // To be removed
-      val embedIdFilter = settings.embedId match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
-              ))
-      }
+      val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
 
       val filters =
         List(
@@ -174,12 +145,7 @@ trait DraftConceptSearchService {
           tagFilter,
           statusFilter,
           userFilter,
-          // To be added
-          // embedResourceAndIdFilter
-          // To be removed
-          embedResourceFilter,
-          // To be removed
-          embedIdFilter
+          embedResourceAndIdFilter
         )
 
       val filteredSearch = queryBuilder.filter(filters.flatten)

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -112,9 +112,9 @@ trait DraftConceptSearchService {
                 simpleStringQuery(query).field(s"content.$language", 1),
                 simpleStringQuery(query).field(s"tags.$language", 1),
                 idsQuery(query)
-              )
-                ++ buildNestedLanguageFieldForEmbeds(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                buildNestedLanguageFieldForEmbeds(None, Some(query), settings.searchLanguage, settings.fallback)
+              ) ++
+                buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
+                buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
             )
         )
 
@@ -134,10 +134,8 @@ trait DraftConceptSearchService {
         case lang                             => (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val embedResourceAndIdFilter = buildNestedLanguageFieldForEmbeds(settings.embedResource,
-                                                                       settings.embedId,
-                                                                       settings.searchLanguage,
-                                                                       settings.fallback)
+      val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
 
       val filters =
         List(idFilter, languageFilter, subjectFilter, tagFilter, statusFilter, userFilter, embedResourceAndIdFilter)

--- a/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/DraftConceptSearchService.scala
@@ -113,8 +113,14 @@ trait DraftConceptSearchService {
                 simpleStringQuery(query).field(s"tags.$language", 1),
                 idsQuery(query)
               ) ++
+                // To be removed
+                buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
+                // To be removed
+                buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
+              // To be added
+              /*++
                 buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
+                buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)*/
             )
         )
 
@@ -134,11 +140,47 @@ trait DraftConceptSearchService {
         case lang                             => (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val embedResourceAndIdFilter =
-        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
+      // To be added
+      /* val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)*/
+
+      // To be removed
+      val embedResourceFilter = settings.embedResource match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      // To be removed
+      val embedIdFilter = settings.embedId match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
+              ))
+      }
 
       val filters =
-        List(idFilter, languageFilter, subjectFilter, tagFilter, statusFilter, userFilter, embedResourceAndIdFilter)
+        List(
+          idFilter,
+          languageFilter,
+          subjectFilter,
+          tagFilter,
+          statusFilter,
+          userFilter,
+          // To be added
+          // embedResourceAndIdFilter
+          // To be removed
+          embedResourceFilter,
+          // To be removed
+          embedIdFilter
+        )
 
       val filteredSearch = queryBuilder.filter(filters.flatten)
 

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -64,7 +64,9 @@ trait PublishedConceptIndexService {
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++
           generateLanguageSupportedFieldList("tags", keepRaw = true) ++
+          // To be removed
           generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          // To be removed
           generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptIndexService.scala
@@ -54,7 +54,12 @@ trait PublishedConceptIndexService {
             keywordField("language")
           ),
           dateField("lastUpdated"),
-          keywordField("license")
+          keywordField("license"),
+          nestedField("embedResourcesAndIds").fields(
+            keywordField("resource"),
+            keywordField("id"),
+            keywordField("language")
+          )
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("content") ++

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -114,9 +114,9 @@ trait PublishedConceptSearchService {
                   simpleStringQuery(query).field(s"title.$language", 2),
                   simpleStringQuery(query).field(s"content.$language", 1),
                   idsQuery(query)
-                ) ++
-                  buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
-                  buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
+                )
+                  ++ buildNestedLanguageFieldForEmbeds(Some(query), None, settings.searchLanguage, settings.fallback) ++
+                  buildNestedLanguageFieldForEmbeds(None, Some(query), settings.searchLanguage, settings.fallback)
               )
           )
       }
@@ -138,27 +138,12 @@ trait PublishedConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val embedResourceFilter = settings.embedResource match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
-              ))
-      }
+      val embedResourceAndIdFilter = buildNestedLanguageFieldForEmbeds(settings.embedResource,
+                                                                       settings.embedId,
+                                                                       settings.searchLanguage,
+                                                                       settings.fallback)
 
-      val embedIdFilter = settings.embedId match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
-              ))
-      }
-
-      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, embedResourceFilter, embedIdFilter)
+      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, embedResourceAndIdFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
       val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -115,14 +115,8 @@ trait PublishedConceptSearchService {
                   simpleStringQuery(query).field(s"content.$language", 1),
                   idsQuery(query)
                 ) ++
-                  // To be removed
-                  buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
-                  // To be removed
-                  buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
-                // To be added
-                /*++
                   buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                  buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)*/
+                  buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
               )
           )
       }
@@ -144,43 +138,15 @@ trait PublishedConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      // To be added
-      /* val embedResourceAndIdFilter =
-        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)*/
-
-      // To be removed
-      val embedResourceFilter = settings.embedResource match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
-              ))
-      }
-
-      // To be removed
-      val embedIdFilter = settings.embedId match {
-        case Some("") | None => None
-        case Some(q) =>
-          Some(
-            boolQuery()
-              .should(
-                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
-              ))
-      }
+      val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
 
       val filters = List(
         idFilter,
         languageFilter,
         subjectFilter,
         tagFilter,
-        // To be added
-        // embedResourceAndIdFilter,
-        // To be removed
-        embedResourceFilter,
-        // To be removed
-        embedIdFilter
+        embedResourceAndIdFilter
       )
 
       val filteredSearch = queryBuilder.filter(filters.flatten)

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -115,8 +115,14 @@ trait PublishedConceptSearchService {
                   simpleStringQuery(query).field(s"content.$language", 1),
                   idsQuery(query)
                 ) ++
+                  // To be removed
+                  buildTermQueryForField(query, "embedResources", settings.searchLanguage, settings.fallback) ++
+                  // To be removed
+                  buildTermQueryForField(query, "embedIds", settings.searchLanguage, settings.fallback)
+                // To be added
+                /*++
                   buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                  buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
+                  buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)*/
               )
           )
       }
@@ -138,10 +144,45 @@ trait PublishedConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val embedResourceAndIdFilter =
-        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
+      // To be added
+      /* val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)*/
 
-      val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, embedResourceAndIdFilter)
+      // To be removed
+      val embedResourceFilter = settings.embedResource match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedResources", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      // To be removed
+      val embedIdFilter = settings.embedId match {
+        case Some("") | None => None
+        case Some(q) =>
+          Some(
+            boolQuery()
+              .should(
+                buildTermQueryForField(q, "embedIds", settings.searchLanguage, settings.fallback)
+              ))
+      }
+
+      val filters = List(
+        idFilter,
+        languageFilter,
+        subjectFilter,
+        tagFilter,
+        // To be added
+        // embedResourceAndIdFilter,
+        // To be removed
+        embedResourceFilter,
+        // To be removed
+        embedIdFilter
+      )
+
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
       val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -114,9 +114,9 @@ trait PublishedConceptSearchService {
                   simpleStringQuery(query).field(s"title.$language", 2),
                   simpleStringQuery(query).field(s"content.$language", 1),
                   idsQuery(query)
-                )
-                  ++ buildNestedLanguageFieldForEmbeds(Some(query), None, settings.searchLanguage, settings.fallback) ++
-                  buildNestedLanguageFieldForEmbeds(None, Some(query), settings.searchLanguage, settings.fallback)
+                ) ++
+                  buildNestedEmbedField(Some(query), None, settings.searchLanguage, settings.fallback) ++
+                  buildNestedEmbedField(None, Some(query), settings.searchLanguage, settings.fallback)
               )
           )
       }
@@ -138,10 +138,8 @@ trait PublishedConceptSearchService {
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
-      val embedResourceAndIdFilter = buildNestedLanguageFieldForEmbeds(settings.embedResource,
-                                                                       settings.embedId,
-                                                                       settings.searchLanguage,
-                                                                       settings.fallback)
+      val embedResourceAndIdFilter =
+        buildNestedEmbedField(settings.embedResource, settings.embedId, settings.searchLanguage, settings.fallback)
 
       val filters = List(idFilter, languageFilter, subjectFilter, tagFilter, embedResourceAndIdFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -61,7 +61,7 @@ trait SearchConverterService {
           case a  => Some(a)
       })
 
-      attributes.find(attr => attr.nonEmpty).get
+      attributes.find(attr => attr.nonEmpty).getOrElse(None)
     }
 
     private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -39,10 +39,6 @@ trait SearchConverterService {
       document.body()
     }
 
-    private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {
-      EmbedValues(resource = getEmbedResource(embed), id = getEmbedId(embed), language = language)
-    }
-
     private def getEmbedResource(embed: Element): Option[String] = {
 
       embed.attr("data-resource") match {
@@ -65,11 +61,11 @@ trait SearchConverterService {
           case a  => Some(a)
       })
 
-      attributes.find(attr => attr.nonEmpty) match {
-        case None           => None
-        case Some(Some("")) => None
-        case Some(a)        => a
-      }
+      attributes.find(attr => attr.nonEmpty).get
+    }
+
+    private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {
+      EmbedValues(resource = getEmbedResource(embed), id = getEmbedId(embed), language = language)
     }
 
     private[service] def getEmbedValues(html: String, language: String): List[EmbedValues] = {

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -10,7 +10,7 @@ package no.ndla.conceptapi.service.search
 import java.lang.Math.max
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.http.search.SearchResponse
-import com.sksamuel.elastic4s.searches.queries.BoolQuery
+import com.sksamuel.elastic4s.searches.queries.{BoolQuery, NestedQuery}
 import com.sksamuel.elastic4s.searches.queries.term.TermQuery
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import com.typesafe.scalalogging.LazyLogging
@@ -48,6 +48,51 @@ trait SearchService {
         })
 
     def hitToApiModel(hit: String, language: String): T
+
+    def buildTermQuery(
+        path: String,
+        resource: Option[String],
+        id: Option[String],
+        language: String,
+        fallback: Boolean
+    ): List[TermQuery] = {
+      val queries = (resource, id) match {
+        case (Some("") | None, Some("") | None) => List.empty
+        case (Some(q), Some("") | None)         => List(termQuery(s"$path.resource", q))
+        case (Some("") | None, Some(q))         => List(termQuery(s"$path.id", q))
+        case (Some(q1), Some(q2))               => List(termQuery(s"$path.resource", q1), termQuery(s"$path.id", q2))
+      }
+      if (queries.isEmpty) return queries
+      if (language == Language.AllLanguages || fallback) queries else queries :+ termQuery(s"$path.language", language)
+    }
+
+    def buildNestedLanguageFieldForEmbeds(
+        resource: Option[String],
+        id: Option[String],
+        language: String,
+        fallback: Boolean
+    ): Option[NestedQuery] = {
+      if ((resource == Some("") || resource == None) && (id == Some("") || id == None)) {
+        return None
+      }
+      if (language == Language.AllLanguages || fallback) {
+        Some(
+          nestedQuery("embedResourcesAndIds").query(
+            boolQuery().must(
+              buildTermQuery("embedResourcesAndIds", resource, id, language, fallback)
+            )
+          )
+        )
+      } else {
+        Some(
+          nestedQuery("embedResourcesAndIds").query(
+            boolQuery().must(
+              buildTermQuery("embedResourcesAndIds", resource, id, language, fallback)
+            )
+          )
+        )
+      }
+    }
 
     def getHits(response: SearchResponse, language: String): Seq[T] = {
       response.totalHits match {

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -49,7 +49,7 @@ trait SearchService {
 
     def hitToApiModel(hit: String, language: String): T
 
-    def buildTermQuery(
+    def buildTermQueryForEmbed(
         path: String,
         resource: Option[String],
         id: Option[String],
@@ -66,7 +66,7 @@ trait SearchService {
       if (language == Language.AllLanguages || fallback) queries else queries :+ termQuery(s"$path.language", language)
     }
 
-    def buildNestedLanguageFieldForEmbeds(
+    def buildNestedEmbedField(
         resource: Option[String],
         id: Option[String],
         language: String,
@@ -79,7 +79,7 @@ trait SearchService {
         Some(
           nestedQuery("embedResourcesAndIds").query(
             boolQuery().must(
-              buildTermQuery("embedResourcesAndIds", resource, id, language, fallback)
+              buildTermQueryForEmbed("embedResourcesAndIds", resource, id, language, fallback)
             )
           )
         )
@@ -87,7 +87,7 @@ trait SearchService {
         Some(
           nestedQuery("embedResourcesAndIds").query(
             boolQuery().must(
-              buildTermQuery("embedResourcesAndIds", resource, id, language, fallback)
+              buildTermQueryForEmbed("embedResourcesAndIds", resource, id, language, fallback)
             )
           )
         )

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchService.scala
@@ -205,18 +205,5 @@ trait SearchService {
         case t: Throwable => Failure(t)
       }
     }
-
-    def buildTermQueryForField(
-        query: String,
-        field: String,
-        language: String,
-        fallback: Boolean
-    ): Seq[TermQuery] = {
-      if (language == Language.AllLanguages || fallback) {
-        Language.languageAnalyzers.map(lang => termQuery(s"$field.${lang.lang}.raw", query))
-      } else {
-        Seq(termQuery(s"$field.$language.raw", query))
-      }
-    }
   }
 }

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -672,7 +672,8 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
   test("that search on embedId and embedResource only returns results matching both params") {
     val Success(search) =
       draftConceptSearchService.all(
-        searchSettings.copy(embedId = Some("test.image"), embedResource=(Some("image")), searchLanguage = Language.AllLanguages))
+        searchSettings
+          .copy(embedId = Some("test.image"), embedResource = (Some("image")), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(0)
   }

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -679,7 +679,11 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
           .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
-    search.results.head.id should be(9)
+    // To be added
+    // search.results.head.id should be(9)
+
+    // To be removed
+    search.results.head.id should be(10)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -679,11 +679,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
           .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
-    // To be added
-    // search.results.head.id should be(9)
-
-    // To be removed
-    search.results.head.id should be(10)
+    search.results.head.id should be(9)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -127,7 +127,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     tags = Seq(ConceptTags(Seq("stor", "klovn"), "nb")),
     subjectIds = Set("urn:subject:1", "urn:subject:100"),
     status = Status(current = ConceptStatus.PUBLISHED, other = Set.empty),
-    metaImage = Seq(ConceptMetaImage("test.image", "imagealt", "nb"))
+    metaImage = Seq(ConceptMetaImage("test.image", "imagealt", "nb"), ConceptMetaImage("test.url2", "imagealt", "en"))
   )
 
   val concept10: Concept = TestData.sampleConcept.copy(
@@ -139,7 +139,10 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     subjectIds = Set("urn:subject:2"),
     status = Status(current = ConceptStatus.TRANSLATED, other = Set(ConceptStatus.PUBLISHED)),
     updatedBy = Seq("Test1"),
-    visualElement = List(VisualElement("""<embed data-resource="image" data-url="test.url" />""", "nb"))
+    visualElement = List(
+      VisualElement(
+        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""",
+        "nb"))
   )
 
   val concept11: Concept = TestData.sampleConcept.copy(id = Option(11),
@@ -610,7 +613,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
   test("that search on embedResource matches visual element") {
     val Success(search) =
       draftConceptSearchService.all(
-        searchSettings.copy(embedResource = Some("image"), searchLanguage = Language.AllLanguages))
+        searchSettings.copy(embedResource = Some("video"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
     search.results.head.id should be(10)
@@ -639,7 +642,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
   test("that search on query parameter as embedResource matches visual element") {
     val Success(search) =
       draftConceptSearchService.matchingQuery(
-        "image",
+        "video",
         searchSettings.copy()
       )
 
@@ -669,13 +672,14 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     search.results.head.id should be(2)
   }
 
-  test("that search on embedId and embedResource only returns results matching both params") {
+  test("that search on embedId and embedResource only returns results with an embed matching both params") {
     val Success(search) =
       draftConceptSearchService.all(
         searchSettings
-          .copy(embedId = Some("test.image"), embedResource = (Some("image")), searchLanguage = Language.AllLanguages))
+          .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
 
-    search.totalCount should be(0)
+    search.totalCount should be(1)
+    search.results.head.id should be(9)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -669,6 +669,14 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     search.results.head.id should be(2)
   }
 
+  test("that search on embedId and embedResource only returns results matching both params") {
+    val Success(search) =
+      draftConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.image"), embedResource=(Some("image")), searchLanguage = Language.AllLanguages))
+
+    search.totalCount should be(0)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -639,7 +639,11 @@ class PublishedConceptSearchServiceTest
           .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
-    search.results.head.id should be(9)
+    // To be added
+    // search.results.head.id should be(9)
+
+    // To be removed
+    search.results.head.id should be(10)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -123,7 +123,7 @@ class PublishedConceptSearchServiceTest
     content = List(ConceptContent("<p>Bilde av <em>Baldurs</em> som har  mareritt.", "nb")),
     tags = Seq(ConceptTags(Seq("stor", "klovn"), "nb")),
     subjectIds = Set("urn:subject:1", "urn:subject:100"),
-    metaImage = Seq(ConceptMetaImage("test.image", "imagealt", "nb"))
+    metaImage = Seq(ConceptMetaImage("test.image", "imagealt", "nb"), ConceptMetaImage("test.url2", "imagealt", "en"))
   )
 
   val concept10: Concept = TestData.sampleConcept.copy(
@@ -133,7 +133,7 @@ class PublishedConceptSearchServiceTest
     tags = Seq(ConceptTags(Seq("cageowl"), "en"), ConceptTags(Seq("burugle"), "nb")),
     updated = DateTime.now().minusDays(1).toDate,
     subjectIds = Set("urn:subject:2"),
-    visualElement = List(VisualElement("""<embed data-resource="image" data-url="test.url" />""", "nb"))
+    visualElement = List(VisualElement("""<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""", "nb"))
   )
 
   val concept11: Concept = TestData.sampleConcept.copy(id = Option(11),
@@ -570,7 +570,7 @@ class PublishedConceptSearchServiceTest
   test("that search on embedResource matches visual element") {
     val Success(search) =
       publishedConceptSearchService.all(
-        searchSettings.copy(embedResource = Some("image"), searchLanguage = Language.AllLanguages))
+        searchSettings.copy(embedResource = Some("video"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
     search.results.head.id should be(10)
@@ -599,7 +599,7 @@ class PublishedConceptSearchServiceTest
   test("that search on query parameter as embedResource matches visual element") {
     val Success(search) =
       publishedConceptSearchService.matchingQuery(
-        "image",
+        "video",
         searchSettings.copy()
       )
 
@@ -627,6 +627,16 @@ class PublishedConceptSearchServiceTest
 
     search.totalCount should be(1)
     search.results.head.id should be(2)
+  }
+
+  test("that search on embedId and embedResource only returns results with an embed matching both params") {
+    val Success(search) =
+      publishedConceptSearchService.all(
+        searchSettings
+          .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
+
+    search.totalCount should be(1)
+    search.results.head.id should be(9)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -639,11 +639,7 @@ class PublishedConceptSearchServiceTest
           .copy(embedId = Some("test.url2"), embedResource = Some("image"), searchLanguage = Language.AllLanguages))
 
     search.totalCount should be(1)
-    // To be added
-    // search.results.head.id should be(9)
-
-    // To be removed
-    search.results.head.id should be(10)
+    search.results.head.id should be(9)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -133,7 +133,10 @@ class PublishedConceptSearchServiceTest
     tags = Seq(ConceptTags(Seq("cageowl"), "en"), ConceptTags(Seq("burugle"), "nb")),
     updated = DateTime.now().minusDays(1).toDate,
     subjectIds = Set("urn:subject:2"),
-    visualElement = List(VisualElement("""<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""", "nb"))
+    visualElement = List(
+      VisualElement(
+        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""",
+        "nb"))
   )
 
   val concept11: Concept = TestData.sampleConcept.copy(id = Option(11),


### PR DESCRIPTION
Fixes NDLANO/Issues#2521
Fixes NDLANO/Issues#2510

I forklaringer og artikler blir alle embed/metabilde/visuelt element mappet til et objekt med felter (id, resource, language). Dersom man søker på embedId og embedResource samtidig skal man nå kun få resultater som har et matchende objekt. Language er også lagt på for å begrense treff dersom det søkes på et spesifikt språk.

Se også PR for search-api https://github.com/NDLANO/search-api/pull/143