### PR TITLE
Search on embed id now supports multiple ids in one embed

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/model/search/EmbedValues.scala
+++ b/src/main/scala/no/ndla/conceptapi/model/search/EmbedValues.scala
@@ -8,7 +8,7 @@
 package no.ndla.conceptapi.model.search
 
 case class EmbedValues(
-    id: Option[String],
+    id: List[String],
     resource: Option[String],
     language: String
 )

--- a/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/SearchConverterService.scala
@@ -71,22 +71,6 @@ trait SearchConverterService {
     }
 
     // To be removed
-    private def getEmbedIds(embed: Element): List[String] = {
-      val attributesToKeep = List(
-        "data-videoid",
-        "data-url",
-        "data-resource_id",
-        "data-content-id",
-      )
-
-      attributesToKeep.flatMap(attr =>
-        embed.attr(attr) match {
-          case "" => None
-          case a  => Some(a)
-      })
-    }
-
-    // To be removed
     private def getEmbedResourcesToIndex(visualElement: Seq[domain.VisualElement]): SearchableLanguageList = {
       val visualElementTuples = visualElement.map(v => v.language -> getEmbedResources(v.visualElement))
       val attrsGroupedByLanguage = visualElementTuples.groupBy(_._1)
@@ -119,7 +103,7 @@ trait SearchConverterService {
       }
     }
 
-    private def getEmbedId(embed: Element): Option[String] = {
+    private def getEmbedIds(embed: Element): List[String] = {
       val attributesToKeep = List(
         "data-videoid",
         "data-url",
@@ -127,17 +111,16 @@ trait SearchConverterService {
         "data-content-id",
       )
 
-      val attributes = attributesToKeep.map(attr =>
-        embed.attr(attr) match {
-          case "" => None
-          case a  => Some(a)
-      })
-
-      attributes.find(attr => attr.nonEmpty).getOrElse(None)
+      attributesToKeep
+        .flatMap(attr =>
+          embed.attr(attr) match {
+            case "" => None
+            case a  => Some(a)
+        })
     }
 
     private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {
-      EmbedValues(resource = getEmbedResource(embed), id = getEmbedId(embed), language = language)
+      EmbedValues(resource = getEmbedResource(embed), id = getEmbedIds(embed), language = language)
     }
 
     private[service] def getEmbedValues(html: String, language: String): List[EmbedValues] = {
@@ -152,7 +135,7 @@ trait SearchConverterService {
                                                metaImage: Seq[domain.ConceptMetaImage]): List[EmbedValues] = {
       val visualElementTuples = visualElement.map(v => getEmbedValues(v.visualElement, v.language)).flatten
       val metaImageTuples =
-        metaImage.map(m => EmbedValues(id = Some(m.imageId), resource = Some("image"), language = m.language))
+        metaImage.map(m => EmbedValues(id = List(m.imageId), resource = Some("image"), language = m.language))
       (visualElementTuples ++ metaImageTuples).toList
 
     }

--- a/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/DraftConceptSearchServiceTest.scala
@@ -141,7 +141,7 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
     updatedBy = Seq("Test1"),
     visualElement = List(
       VisualElement(
-        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""",
+        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" data-resource_id="test.id2" />""",
         "nb"))
   )
 
@@ -680,6 +680,23 @@ class DraftConceptSearchServiceTest extends IntegrationSuite(EnableElasticsearch
 
     search.totalCount should be(1)
     search.results.head.id should be(9)
+  }
+
+  test("That search on embed id supports embed with multiple id attributes") {
+    val Success(search1) =
+      draftConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.url2"))
+      )
+    val Success(search2) =
+      draftConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.id2"))
+      )
+
+    search1.totalCount should be(1)
+    search1.results.head.id should be(10)
+    search2.totalCount should be(1)
+    search2.results.head.id should be(10)
+
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchServiceTest.scala
@@ -135,7 +135,7 @@ class PublishedConceptSearchServiceTest
     subjectIds = Set("urn:subject:2"),
     visualElement = List(
       VisualElement(
-        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" />""",
+        """<embed data-resource="image" data-url="test.url" /><embed data-resource="video" data-url="test.url2" data-resource_id="test.id2" />""",
         "nb"))
   )
 
@@ -640,6 +640,23 @@ class PublishedConceptSearchServiceTest
 
     search.totalCount should be(1)
     search.results.head.id should be(9)
+  }
+
+  test("That search on embed id supports embed with multiple id attributes") {
+    val Success(search1) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.url2"))
+      )
+    val Success(search2) =
+      publishedConceptSearchService.all(
+        searchSettings.copy(embedId = Some("test.id2"))
+      )
+
+    search1.totalCount should be(1)
+    search1.results.head.id should be(10)
+    search2.totalCount should be(1)
+    search2.results.head.id should be(10)
+
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {


### PR DESCRIPTION
En enkelt embed kan inneholde flere ider (feks id og url). 

Endrer ID i EmbedValues til å være en liste for å støtte dette.

Gjelder også search-api: https://github.com/NDLANO/search-api/pull/146