### PR TITLE
Forcing string query to match exactly

### DIFF
--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -105,7 +105,7 @@ trait PublishedConceptSearchService {
 
       val fullQuery = settings.exactTitleMatch match {
         case true =>
-          boolQuery().must(termQuery(s"title.$language.lower", query))
+          boolQuery().must(simpleStringQuery("\"" + query + "\"").field(s"title.$language.lower", 2))
         case false =>
           boolQuery().must(
             boolQuery()

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -105,7 +105,7 @@ trait PublishedConceptSearchService {
 
       val fullQuery = settings.exactTitleMatch match {
         case true =>
-          boolQuery().must(simpleStringQuery("\"" + query + "\"").field(s"title.$language.lower", 2))
+          boolQuery().must(simpleStringQuery(s"""$query""").field(s"title.$language.lower", 2))
         case false =>
           boolQuery().must(
             boolQuery()

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -105,7 +105,7 @@ trait PublishedConceptSearchService {
 
       val fullQuery = settings.exactTitleMatch match {
         case true =>
-          boolQuery().must(simpleStringQuery(s"""\"$query\"""").field(s"title.$language.lower", 2))
+          boolQuery().must(simpleStringQuery(s""""$query"""").field(s"title.$language.lower", 2))
         case false =>
           boolQuery().must(
             boolQuery()

--- a/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
+++ b/src/main/scala/no/ndla/conceptapi/service/search/PublishedConceptSearchService.scala
@@ -105,7 +105,7 @@ trait PublishedConceptSearchService {
 
       val fullQuery = settings.exactTitleMatch match {
         case true =>
-          boolQuery().must(simpleStringQuery(s"""$query""").field(s"title.$language.lower", 2))
+          boolQuery().must(simpleStringQuery(s"""\"$query\"""").field(s"title.$language.lower", 2))
         case false =>
           boolQuery().must(
             boolQuery()


### PR DESCRIPTION
Gjør et forsøk på å få eksakt match på tvers av felt.

Problemet med gammel versjon er at om du ikkje sender inn language eller spesifiserer fallback, så søkes det på 'title.*.lower' men term-query støtter ikkje wildcard i feltnavn så då får du ingen treff.

Endringa her er å wrappe søket i "" for at du skal få eksakt treff på det du søker på, og med simple-search for at det skal fungere med * i feltnavn. Eg forsøkte å spesifisere query som `s"\"${query}\""` men det likte ikkje sbt og eg fikk feilmelding. Derfor gammeldags stringkonkantingering med pluss.

Test:
* Deploy lokalt og søk etter forklaringer med exact-match=true, fallback=true og language=nn og en query satt til en tittel du veit du har. Både med og uten fallback skal (helst) gi samme treff.